### PR TITLE
Use S3 Histograms to generate colour breaks

### DIFF
--- a/server/src/main/scala/geotrellis/admin/server/AdminActor.scala
+++ b/server/src/main/scala/geotrellis/admin/server/AdminActor.scala
@@ -89,12 +89,12 @@ trait AdminRoutes extends HttpService with CORSSupport {
       get {
         pathPrefix("gt") {
           pathPrefix("errorTile")(errorTile) ~
-            pathPrefix("bounds")(bounds) ~
-            pathPrefix("metadata")(metadata) ~
-            pathPrefix("layers")(layers) ~
-            pathPrefix("attributes")(attributes) ~
-            pathPrefix("tms")(tms) ~
-            pathPrefix("breaks")(breaks)
+          pathPrefix("bounds")(bounds) ~
+          pathPrefix("metadata")(metadata) ~
+          pathPrefix("layers")(layers) ~
+          pathPrefix("attributes")(attributes) ~
+          pathPrefix("tms")(tms) ~
+          pathPrefix("breaks")(breaks)
         }
       }
     }
@@ -200,11 +200,11 @@ trait AdminRoutes extends HttpService with CORSSupport {
       val layerId = LayerId(layer, zoom)
 
       pathPrefix("grid")(tmsGrid(layerId, key)) ~
-        pathPrefix("type")(tmsType(layerId, key)) ~
-        pathPrefix("breaks")(tmsBreaks(layerId, key)) ~
-        pathPrefix("histo")(tmsHisto(layerId, key)) ~
-        pathPrefix("stats")(tmsStats(layerId, key)) ~
-        pathEnd(serveTile(layerId, key))
+      pathPrefix("type")(tmsType(layerId, key)) ~
+      pathPrefix("breaks")(tmsBreaks(layerId, key)) ~
+      pathPrefix("histo")(tmsHisto(layerId, key)) ~
+      pathPrefix("stats")(tmsStats(layerId, key)) ~
+      pathEnd(serveTile(layerId, key))
     }
   }
 


### PR DESCRIPTION
## TODO
- [x] Find out how `Histogram`s work
- [x] Alter `breaks` function to check for an S3 histogram
- [x] Reparsing `Histogram` from JSON
- [x] Testing

## Motivation
Currently, class breaks are generated by pulling down the entire RDD of a layer at zoom level 4, and then calling `classBreaksDouble`. `classBreaksDouble` functions by creating an aggregated `Histogram` from the histograms of each tile in the layer, then calling some utility functions to produce the final `Array[Double]`. 

However, some layers have histogram data precomputed on S3. If they do, this can be pulled and reparsed into a `Histogram` to avoid the pulling down of the entire RDD.